### PR TITLE
Conversion methods between Matrix3, Matrix4 and Quaternion

### DIFF
--- a/include/Matrix3.hpp
+++ b/include/Matrix3.hpp
@@ -1,11 +1,15 @@
+/*
+ * Copyright (C) 2021 Amara Sami, Dallard Thomas, Nardone William, Six Jonathan
+ * This file is subject to the LGNU license terms in the LICENSE file
+ * found in the top-level directory of this distribution.
+ */
+
 #pragma once
 #include "types.hpp"
 #include "Vector3.hpp"
 
-#ifdef _DEBUG
 #include <iomanip>
 #include <iostream>
-#endif
 
 namespace GPM
 {
@@ -39,9 +43,7 @@ struct Matrix3
     constexpr f32       operator[]      (const u8 i)        const noexcept;
     constexpr f32       operator()      (const u8 i, const u8 j) const noexcept;
 
-    #ifdef _DEBUG
-    friend std::ostream& operator<<(std::ostream& os, const Matrix3& m) noexcept;
-    #endif
+    friend std::ostream& operator<<     (std::ostream& os, const Matrix3& m) noexcept;
 };
 
 using Mat3 = Matrix3;

--- a/include/Matrix4.hpp
+++ b/include/Matrix4.hpp
@@ -1,11 +1,16 @@
+/*
+ * Copyright (C) 2021 Amara Sami, Dallard Thomas, Nardone William, Six Jonathan
+ * This file is subject to the LGNU license terms in the LICENSE file
+ * found in the top-level directory of this distribution.
+ */
+
 #pragma once
+
 #include "types.hpp"
 #include "Vector4.hpp"
 
-#ifdef _DEBUG
 #include <iomanip>
 #include <iostream>
-#endif
 
 namespace GPM
 {
@@ -39,9 +44,7 @@ struct Matrix4
     constexpr f32       operator[]      (const u8 i)             const noexcept;
     constexpr f32       operator()      (const u8 i, const u8 j) const noexcept;
 
-    #ifdef _DEBUG
-    friend std::ostream& operator<<(std::ostream& os, const Matrix4& m) noexcept;
-    #endif
+    friend std::ostream& operator<<     (std::ostream& os, const Matrix4& m) noexcept;
 };
 
 using Mat4 = Matrix4;

--- a/include/Quaternion.hpp
+++ b/include/Quaternion.hpp
@@ -1,12 +1,16 @@
+/*
+ * Copyright (C) 2021 Amara Sami, Dallard Thomas, Nardone William, Six Jonathan
+ * This file is subject to the LGNU license terms in the LICENSE file
+ * found in the top-level directory of this distribution.
+ */
+
 #pragma once
 
 #include "constants.hpp"
 #include "types.hpp"
 #include "Vector3.hpp"
 
-#ifdef _DEBUG
 #include <iostream>
-#endif
 
 namespace GPM
 {
@@ -47,9 +51,7 @@ struct Quaternion
     constexpr f32               operator[]  (const u8 i)                            const noexcept;
     constexpr f32&              operator[]  (const u8 i)                            noexcept;
 
-    #ifdef _DEBUG
-    friend std::ostream& operator<<(std::ostream& os, const Quaternion& q) noexcept;
-    #endif
+    friend std::ostream&        operator<<  (std::ostream& os, const Quaternion& q) noexcept;
 };
 
 using Quat = Quaternion;

--- a/include/Vector2.hpp
+++ b/include/Vector2.hpp
@@ -1,12 +1,14 @@
+/*
+ * Copyright (C) 2021 Amara Sami, Dallard Thomas, Nardone William, Six Jonathan
+ * This file is subject to the LGNU license terms in the LICENSE file
+ * found in the top-level directory of this distribution.
+ */
+
 #pragma once
 
-#include <cmath>
 #include <cfloat>
-
-#ifdef _DEBUG
-#include <iomanip>
+#include <cmath>
 #include <iostream>
-#endif
 
 namespace GPM
 {
@@ -14,8 +16,8 @@ namespace GPM
 struct Vector2
 {
     // Data members
-    f32 x{.0f};
-    f32 y{.0f};
+    f32 x;
+    f32 y;
     
     // Static methods (pseudo-constructors)
     static constexpr Vector2 zero   () noexcept;
@@ -72,9 +74,7 @@ struct Vector2
     constexpr Vector2   operator*           (const f32 k)       const noexcept;
     constexpr Vector2   operator/           (const f32 k)       const noexcept;
 
-    #ifdef _DEBUG
-    friend std::ostream& operator<<(std::ostream& os, const Vector2& v) noexcept;
-    #endif
+    friend std::ostream& operator<<         (std::ostream& os, const Vector2& v) noexcept;
 };
 
 using Vec2 = Vector2;

--- a/include/Vector3.hpp
+++ b/include/Vector3.hpp
@@ -1,11 +1,14 @@
+/*
+ * Copyright (C) 2021 Amara Sami, Dallard Thomas, Nardone William, Six Jonathan
+ * This file is subject to the LGNU license terms in the LICENSE file
+ * found in the top-level directory of this distribution.
+ */
+
 #pragma once
 
 #include <cfloat>
 #include <cmath>
-
-#ifdef _DEBUG
 #include <iostream>
-#endif
 
 namespace GPM
 {
@@ -32,8 +35,8 @@ struct Vector3
     constexpr bool      isNull              ()                              const noexcept;
     constexpr bool      isOrthogonalTo      (const Vector3& v)              const noexcept;
     constexpr bool      isNormalized        ()                              const noexcept;
-    constexpr  bool     isOrthonormalTo     (const Vector3& v)              const noexcept;
-    constexpr  bool     isColinearTo        (const Vector3& v)              const noexcept;
+    constexpr bool      isOrthonormalTo     (const Vector3& v)              const noexcept;
+    constexpr bool      isColinearTo        (const Vector3& v)              const noexcept;
     bool                isEqualTo           (const Vector3& v,
                                              const f32 eps = FLT_EPSILON)   const noexcept;
     bool                isNotEqualTo        (const Vector3& v,
@@ -77,9 +80,7 @@ struct Vector3
     constexpr Vector3	operator*           (const f32 k)                   const noexcept;
     constexpr Vector3	operator/           (const f32 k)                   const noexcept;
 
-    #ifdef _DEBUG
-    friend std::ostream& operator<<(std::ostream& os, const Vector3& v) noexcept;
-    #endif
+    friend std::ostream& operator<<         (std::ostream& os, const Vector3& v) noexcept;
 };
 
 using Vec3 = Vector3;

--- a/include/Vector4.hpp
+++ b/include/Vector4.hpp
@@ -1,5 +1,15 @@
+/*
+ * Copyright (C) 2021 Amara Sami, Dallard Thomas, Nardone William, Six Jonathan
+ * This file is subject to the LGNU license terms in the LICENSE file
+ * found in the top-level directory of this distribution.
+ */
+
 #pragma once
+
 #include "Vector3.hpp"
+#include <cfloat>
+#include <cmath>
+#include <iostream>
 
 namespace GPM
 {
@@ -7,10 +17,10 @@ namespace GPM
 struct Vector4
 {
     // Data members
-    Vec3    xyz{Vec3::zero()};
-    f32     w  {.0f};
+    Vec3    xyz;
+    f32     w;
 
-    constexpr Vector4() noexcept = default;
+    Vector4() noexcept;
     constexpr Vector4(const Vec3& v, const f32 w = 1.f) noexcept;
     constexpr Vector4(const f32 x, const f32 y, const f32 z, const f32 w = 1.f) noexcept;
 
@@ -23,9 +33,7 @@ struct Vector4
     constexpr Vector4 operator*  (const f32 k) const noexcept;
     constexpr Vector4 operator/  (const f32 k) const noexcept;
 
-    #ifdef _DEBUG
     friend std::ostream& operator<<(std::ostream& os, const Vector4& v) noexcept;
-    #endif
 };
 
 using Vec4 = Vector4;

--- a/include/Vector4.hpp
+++ b/include/Vector4.hpp
@@ -22,6 +22,10 @@ struct Vector4
     constexpr Vector4 operator/  (const Vector4& v) const noexcept;
     constexpr Vector4 operator*  (const f32 k) const noexcept;
     constexpr Vector4 operator/  (const f32 k) const noexcept;
+
+    #ifdef _DEBUG
+    friend std::ostream& operator<<(std::ostream& os, const Vector4& v) noexcept;
+    #endif
 };
 
 using Vec4 = Vector4;

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
-#define PI     3.141592653589793
-#define TWO_PI 6.283185307179586
+#define HALF_PI 1.570796326794896
+#define PI      3.141592653589793
+#define TWO_PI  6.283185307179586
 #define TAU    TWO_PI

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -1,6 +1,12 @@
+/*
+ * Copyright (C) 2021 Amara Sami, Dallard Thomas, Nardone William, Six Jonathan
+ * This file is subject to the LGNU license terms in the LICENSE file
+ * found in the top-level directory of this distribution.
+ */
+ 
 #pragma once
 
-#define HALF_PI 1.570796326794896
-#define PI      3.141592653589793
-#define TWO_PI  6.283185307179586
-#define TAU    TWO_PI
+#define HALF_PI  1.570796326794896
+#define PI       3.141592653589793
+#define TWO_PI   6.283185307179586
+#define TAU      TWO_PI

--- a/include/conversion.hpp
+++ b/include/conversion.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Quaternion.hpp"
+#include "Vector2.hpp"
+#include "Vector3.hpp"
+#include "Vector4.hpp"
+#include "Matrix3.hpp"
+#include "Matrix4.hpp"
+
+namespace GPM
+{
+
+constexpr Mat3       toMatrix3   (const Mat4& m) noexcept;
+constexpr Mat4       toMatrix4   (const Mat3& m) noexcept;
+
+constexpr Mat3       toMatrix3   (const Quat& q) noexcept;
+constexpr Mat4       toMatrix4   (const Quat& q) noexcept;
+
+Quaternion           toQuaternion(const Mat3& m) noexcept;
+Quaternion           toQuaternion(const Mat4& m) noexcept;
+
+#include "../src/conversion.inl"
+
+}

--- a/include/conversion.hpp
+++ b/include/conversion.hpp
@@ -16,8 +16,8 @@ constexpr Mat4       toMatrix4   (const Mat3& m) noexcept;
 constexpr Mat3       toMatrix3   (const Quat& q) noexcept;
 constexpr Mat4       toMatrix4   (const Quat& q) noexcept;
 
-Quaternion           toQuaternion(const Mat3& m) noexcept;
-Quaternion           toQuaternion(const Mat4& m) noexcept;
+Quat                 toQuaternion(const Mat3& m) noexcept;
+Quat                 toQuaternion(const Mat4& m) noexcept;
 
 #include "../src/conversion.inl"
 

--- a/include/conversion.hpp
+++ b/include/conversion.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (C) 2021 Amara Sami, Dallard Thomas, Nardone William, Six Jonathan
+ * This file is subject to the LGNU license terms in the LICENSE file
+ * found in the top-level directory of this distribution.
+ */
+ 
 #pragma once
 
 #include "Quaternion.hpp"

--- a/src/Matrix3.inl
+++ b/src/Matrix3.inl
@@ -154,7 +154,6 @@ inline constexpr f32 Matrix3::operator()(const u8 i, const u8 j) const noexcept
 { return coef[j * MAT3_COL + i]; }
 
 
-#ifdef _DEBUG
 inline std::ostream& operator<<(std::ostream& os, const Matrix3& mat) noexcept
 {
     std::streamsize original = std::cout.precision();
@@ -175,4 +174,3 @@ inline std::ostream& operator<<(std::ostream& os, const Matrix3& mat) noexcept
 
     return os;
 }
-#endif

--- a/src/Matrix4.inl
+++ b/src/Matrix4.inl
@@ -228,7 +228,6 @@ inline constexpr f32 Matrix4::operator()(const u8 i, const u8 j) const noexcept
 { return coef[j * MAT4_COL + i]; }
 
 
-#ifdef _DEBUG
 inline std::ostream& operator<<(std::ostream& os, const Matrix4& mat) noexcept
 {
     std::streamsize original = std::cout.precision();
@@ -249,4 +248,3 @@ inline std::ostream& operator<<(std::ostream& os, const Matrix4& mat) noexcept
 
     return os;
 }
-#endif

--- a/src/Quaternion.inl
+++ b/src/Quaternion.inl
@@ -1,5 +1,5 @@
 /* =================== Static methods (pseudo-constructors) =================== */
-inline Quaternion angleAxis(const f32 angle, const Vec3& axis) noexcept
+inline Quaternion Quaternion::angleAxis(const f32 angle, const Vec3& axis) noexcept
 {
     const f32 halfAngle{angle * .5f};
     return {axis.normalized() * sinf(halfAngle), cosf(halfAngle)};

--- a/src/Quaternion.inl
+++ b/src/Quaternion.inl
@@ -122,7 +122,5 @@ inline constexpr f32& Quaternion::operator[](const u8 i) noexcept
 { return *((f32*)this + i); }
 
 
-#ifdef _DEBUG
 inline std::ostream& operator<<(std::ostream& os, const Quaternion& q) noexcept
 { return os << '[' << q.s << ", " << q.v << ']'; }
-#endif

--- a/src/Vector2.inl
+++ b/src/Vector2.inl
@@ -268,7 +268,6 @@ inline constexpr Vector2 Vector2::operator/(const f32 k) const noexcept
 	return {x * reciprocal, y * reciprocal};
 }
 
-#ifdef _DEBUG
+
 inline std::ostream& operator<<(std::ostream& os, const Vector2& v) noexcept
 { return os << '[' << v.x << ", " << v.y << ']'; }
-#endif

--- a/src/Vector3.inl
+++ b/src/Vector3.inl
@@ -290,7 +290,5 @@ inline constexpr Vector3 Vector3::operator/(const f32 k) const noexcept
 }
 
 
-#ifdef _DEBUG
 inline std::ostream& operator<<(std::ostream& os, const Vector3& v) noexcept
 { return os << '[' << v.x << ", " << v.y << ", " << v.z << ']'; }
-#endif

--- a/src/Vector4.inl
+++ b/src/Vector4.inl
@@ -45,7 +45,5 @@ inline constexpr Vector4 Vector4::operator/(const f32 k) const noexcept
 }
 
 
-#ifdef _DEBUG
 inline std::ostream& operator<<(std::ostream& os, const Vector4& v) noexcept
 { return os << '[' << v.xyz.x << ", " << v.xyz.y << ", " << v.xyz.z << ", " << v.w << ']'; }
-#endif

--- a/src/Vector4.inl
+++ b/src/Vector4.inl
@@ -43,3 +43,9 @@ inline constexpr Vector4 Vector4::operator/(const f32 k) const noexcept
     const f32 reciprocal{1.f / k};
     return {xyz * reciprocal, w * reciprocal};
 }
+
+
+#ifdef _DEBUG
+inline std::ostream& operator<<(std::ostream& os, const Vector4& v) noexcept
+{ return os << '[' << v.xyz.x << ", " << v.xyz.y << ", " << v.xyz.z << ", " << v.w << ']'; }
+#endif

--- a/src/conversion.inl
+++ b/src/conversion.inl
@@ -1,0 +1,95 @@
+/* ================= Inlined conversion methods ================= */
+inline constexpr Mat3 toMatrix3(const Mat4& m) noexcept
+{
+    return
+    {
+        m.coef[0], m.coef[1], m.coef[2],
+        m.coef[4], m.coef[5], m.coef[6],
+        m.coef[8], m.coef[9], m.coef[10]
+    };
+}
+
+
+inline constexpr Mat4 toMatrix4(const Mat3& m) noexcept
+{
+    return
+    {
+        m.coef[0], m.coef[1], m.coef[2], .0f,
+        m.coef[3], m.coef[4], m.coef[5], .0f,
+        m.coef[6], m.coef[7], m.coef[8], .0f,
+               .0f,      .0f,       .0f, 1.f
+    };
+}
+
+
+inline constexpr Mat3 toMatrix3(const Quat& q) noexcept
+{
+    const float x2{q.x() * q.x()}, y2{q.y() * q.y()}, z2{q.z() * q.z()},
+                xy{q.x() * q.y()}, yz{q.y() * q.z()}, xz{q.x() * q.z()},
+                wx{q.s * q.x()},   wy{q.s * q.y()},   wz{q.s * q.z()},
+                s_2{2.f / q.length2()};
+
+    // Column-major
+    return
+    {
+        1.f - s_2 * (y2 + z2),  s_2 * (xy - wz),        s_2 * (xz + wy),
+        s_2 * (xy + wz),        1.f - s_2 * (x2 + z2),  s_2 * (yz - wx),
+        s_2 * (xz - wy),        s_2 * (yz + wx),        1.f - s_2 * (x2 + y2)
+    };
+}
+
+
+inline constexpr Mat4 toMatrix4(const Quat& q) noexcept
+{
+    return toMatrix4(toMatrix3(q));
+}
+
+
+inline Quat toQuaternion(const Mat3& m) noexcept
+{
+    Quat ret;
+    const f32 trace = m.trace();
+
+    if (trace > .0f)
+    {
+        f32 tmp = sqrtf(trace + 1.f);
+
+        ret.s = tmp * .5f;
+
+        tmp = .5f / tmp;
+
+        ret.v.x = (m[5] - m[7]) * tmp;
+        ret.v.y = (m[6] - m[2]) * tmp;
+        ret.v.z = (m[1] - m[3]) * tmp;
+    }
+
+    else
+    {
+        u8 i = 0;
+        if (m[4] > m[0])      i = 1u;
+        if (m[8] > m[4u * i]) i = 2u;
+
+        const u8 next[3]    = {1u, 2u, 0u},
+                 j          = next[i],
+                 k          = next[j];
+
+        f32 tmp = sqrtf((m(i, j) - (m(j, j) + m(k, k))) + 1.f);
+
+        ret[i] = tmp * .5f;
+
+        if (tmp != .0f)
+            tmp = .5f / tmp;
+
+        ret.v.z = (m(k, j) - m(j, k)) * tmp;
+        ret[j]  = (m(j, i) + m(i, j)) * tmp;
+        ret[k]  = (m(k, i) + m(i, k)) * tmp;
+    }
+
+    return ret;
+}
+
+
+inline Quat toQuaternion(const Mat4& m) noexcept
+{
+    return toQuaternion(toMatrix3(m));
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,6 @@ int main()
     GPM::Quat quat{GPM::Quat::angleAxis(HALF_PI, vec3)};
     GPM::Quat quatMat3{toQuaternion(mat3)};
 
-#ifdef _DEBUG
     std::cerr << "mat3 = " << mat3 << '\n';
     std::cerr << "mat4 = " << mat4 << '\n';
     std::cerr << "vec2 = " << vec2 << '\n';
@@ -32,7 +31,6 @@ int main()
     quatMat3 = toQuaternion(toMatrix3(quatMat3));
 
     std::cerr << "quatMat3 = toQuaternion(toMatrix3(quatMat3)) = " << quatMat3 << '\n';
-#endif
 
     return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,14 +4,35 @@
 #include "Vector3.hpp"
 #include "Vector4.hpp"
 #include "Quaternion.hpp"
+#include "conversion.hpp"
+#include "constants.hpp"
+
+#include <iostream>
+
 int main()
 {
-    GPM::Mat3 ma3;
-    GPM::Mat4 mat4;
-    GPM::Vec2 vec2;
-    GPM::Vec3 vec3;
-    GPM::Vec4 vec4;
-    GPM::Quat quat;
-    
+    GPM::Mat3 mat3 = GPM::Mat3::identity();
+    GPM::Mat4 mat4 = GPM::Mat4::identity();
+    GPM::Vec2 vec2{1.f, 2.f};
+    GPM::Vec3 vec3{-3.f, -2.f, -1.f};
+    GPM::Vec4 vec4{vec3, 1.f};
+    GPM::Quat quat{GPM::Quat::angleAxis(HALF_PI, vec3)};
+    GPM::Quat quatMat3{toQuaternion(mat3)};
+
+#ifdef _DEBUG
+    std::cerr << "mat3 = " << mat3 << '\n';
+    std::cerr << "mat4 = " << mat4 << '\n';
+    std::cerr << "vec2 = " << vec2 << '\n';
+    std::cerr << "vec3 = " << vec3 << '\n';
+    std::cerr << "vec4 = " << vec4 << '\n';
+    std::cerr << "quat = " << quat << '\n';
+    std::cerr << "quatMat3 = " << quatMat3 << '\n';
+    std::cerr << "toMatrix3(quatMat3) = " << toMatrix3(quatMat3) << '\n';
+
+    quatMat3 = toQuaternion(toMatrix3(quatMat3));
+
+    std::cerr << "quatMat3 = toQuaternion(toMatrix3(quatMat3)) = " << quatMat3 << '\n';
+#endif
+
     return 0;
 }


### PR DESCRIPTION
This merge brings conversion functions, namely:

```C++
constexpr Mat3       toMatrix3   (const Mat4& m) noexcept;
constexpr Mat4       toMatrix4   (const Mat3& m) noexcept;
constexpr Mat3       toMatrix3   (const Quat& q) noexcept;
constexpr Mat4       toMatrix4   (const Quat& q) noexcept;
Quat                 toQuaternion(const Mat3& m) noexcept;
Quat                 toQuaternion(const Mat4& m) noexcept;
````

A demonstration is included in [`src/main.cpp`](https://github.com/GP-Engine-team/gpm/blob/d730844e6b19800233c4e08eb4b5c067e78dd717/src/main.cpp#L12)