### PR TITLE
Feature/quick fixes

### DIFF
--- a/include/GPM/DebugOutput.hpp
+++ b/include/GPM/DebugOutput.hpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2021 Amara Sami, Dallard Thomas, Nardone William, Six Jonathan
+ * This file is subject to the LGNU license terms in the LICENSE file
+ * found in the top-level directory of this distribution.
+ */
+
+#pragma once
+
+#include <iomanip>
+#include <iostream>
+
+namespace GPM
+{
+
+std::ostream& operator<<(std::ostream& os, const Matrix3& m)        noexcept;
+std::ostream& operator<<(std::ostream& os, const Matrix4& m)        noexcept;
+std::ostream& operator<<(std::ostream& os, const Quaternion& q)     noexcept;
+std::ostream& operator<<(std::ostream& os, const SplitTransform& m) noexcept;
+std::ostream& operator<<(std::ostream& os, const Transform& m)      noexcept;
+std::ostream& operator<<(std::ostream& os, const Vector2& v)        noexcept;
+std::ostream& operator<<(std::ostream& os, const Vector3& v)        noexcept;
+std::ostream& operator<<(std::ostream& os, const Vector4& v)        noexcept;
+
+#include "DebugOutput.inl"
+
+} // End of namespace GPM

--- a/include/GPM/DebugOutput.inl
+++ b/include/GPM/DebugOutput.inl
@@ -1,0 +1,76 @@
+inline std::ostream& operator<<(std::ostream& os, const Matrix3& mat) noexcept
+{
+    std::streamsize original = std::cout.precision();
+    os << std::setprecision(2);
+
+    for (u8 i{0u}; i < MAT3_COL; ++i)
+    {
+        u8 induction{i};
+        
+        os << "| ";
+        for (u8 j{MAT3_COL}; j--; induction += MAT3_COL)
+            os << std::setw(6) << mat.e[induction] << ' ';
+
+        os << " |";
+
+        if (i != MAT3_COL - 1u)
+            os << '\n';
+    }
+
+    os << std::setprecision(original);
+
+    return os;
+}
+
+
+inline std::ostream& operator<<(std::ostream& os, const Matrix4& mat) noexcept
+{
+    std::streamsize original = std::cout.precision();
+    os << std::setprecision(2);
+
+    for (u8 i{0u}; i < MAT4_COL; ++i)
+    {
+        u8 induction{i};
+        
+        os << "| ";
+        for (u8 j{MAT4_COL}; j--; induction += MAT4_COL)
+            os << std::setw(10) << mat.e[induction] << ' ';
+
+        os << " |";
+        
+        if (i != MAT4_COL - 1u)
+            os << '\n';
+    }
+
+    os << std::setprecision(original);
+
+    return os;
+}
+
+
+inline std::ostream& operator<<(std::ostream& os, const Quaternion& q) noexcept
+{ return os << '[' << q.s << ", " << q.v << ']'; }
+
+
+inline std::ostream& operator<<(std::ostream& os, const SplitTransform& st) noexcept
+{
+    return os << "rotation: "   << st.rotation
+              << "\nposition: " << st.position
+              << "\nscale: "    << st.scale;
+}
+
+
+inline std::ostream& operator<<(std::ostream& os, const Transform& t) noexcept
+{ return os << t.model; }
+
+
+inline std::ostream& operator<<(std::ostream& os, const Vector2& v) noexcept
+{ return os << '[' << v.x << ", " << v.y << ']'; }
+
+
+inline std::ostream& operator<<(std::ostream& os, const Vector3& v) noexcept
+{ return os << '[' << v.x << ", " << v.y << ", " << v.z << ']'; }
+
+
+inline std::ostream& operator<<(std::ostream& os, const Vector4& v) noexcept
+{ return os << '[' << v.xyz.x << ", " << v.xyz.y << ", " << v.xyz.z << ", " << v.w << ']'; }

--- a/include/GPM/Matrix3.hpp
+++ b/include/GPM/Matrix3.hpp
@@ -8,9 +8,6 @@
 #include "types.hpp"
 #include "Vector3.hpp"
 
-#include <iomanip>
-#include <iostream>
-
 namespace GPM
 {
 
@@ -41,8 +38,6 @@ union Matrix3
     constexpr Matrix3   operator*       (const Matrix3& m)  const noexcept;
     constexpr Vec3      operator*       (const Vec3& v)     const noexcept;
     constexpr Matrix3   operator/       (const f32 k)       const noexcept;
-
-    friend std::ostream& operator<<     (std::ostream& os, const Matrix3& m) noexcept;
 };
 
 using Mat3 = Matrix3;

--- a/include/GPM/Matrix3.inl
+++ b/include/GPM/Matrix3.inl
@@ -144,28 +144,3 @@ inline constexpr Matrix3 Matrix3::operator/(const f32 k) const noexcept
         e[6] * reciprocal, e[7] * reciprocal, e[8] * reciprocal
     };
 }
-
-
-inline std::ostream& operator<<(std::ostream& os, const Matrix3& mat) noexcept
-{
-    std::streamsize original = std::cout.precision();
-    os << std::setprecision(2);
-
-    for (u8 i{0u}; i < MAT3_COL; ++i)
-    {
-        u8 induction{i};
-        
-        os << "| ";
-        for (u8 j{MAT3_COL}; j--; induction += MAT3_COL)
-            os << std::setw(6) << mat.e[induction] << ' ';
-
-        os << " |";
-
-        if (i != MAT3_COL - 1u)
-            os << '\n';
-    }
-
-    os << std::setprecision(original);
-
-    return os;
-}

--- a/include/GPM/Matrix4.hpp
+++ b/include/GPM/Matrix4.hpp
@@ -9,9 +9,6 @@
 #include "types.hpp"
 #include "Vector4.hpp"
 
-#include <iomanip>
-#include <iostream>
-
 namespace GPM
 {
 
@@ -51,8 +48,6 @@ union alignas(16) Matrix4
     constexpr Matrix4   operator*       (const Matrix4& m)       const noexcept;
     constexpr Vec4      operator*       (const Vec4& v)          const noexcept;
     constexpr Matrix4   operator/       (const f32 k)            const noexcept;
-
-    friend std::ostream& operator<<     (std::ostream& os, const Matrix4& m) noexcept;
 };
 
 using Mat4 = Matrix4;

--- a/include/GPM/Matrix4.inl
+++ b/include/GPM/Matrix4.inl
@@ -223,28 +223,3 @@ inline constexpr Matrix4 Matrix4::operator/(const f32 k) const noexcept
         e[12] * reciprocal, e[13] * reciprocal, e[14] * reciprocal, e[15] * reciprocal,
     };
 }
-
-
-inline std::ostream& operator<<(std::ostream& os, const Matrix4& mat) noexcept
-{
-    std::streamsize original = std::cout.precision();
-    os << std::setprecision(2);
-
-    for (u8 i{0u}; i < MAT4_COL; ++i)
-    {
-        u8 induction{i};
-        
-        os << "| ";
-        for (u8 j{MAT4_COL}; j--; induction += MAT4_COL)
-            os << std::setw(10) << mat.e[induction] << ' ';
-
-        os << " |";
-        
-        if (i != MAT4_COL - 1u)
-            os << '\n';
-    }
-
-    os << std::setprecision(original);
-
-    return os;
-}

--- a/include/GPM/Quaternion.hpp
+++ b/include/GPM/Quaternion.hpp
@@ -10,8 +10,6 @@
 #include "types.hpp"
 #include "Vector3.hpp"
 
-#include <iostream>
-
 namespace GPM
 {
 
@@ -50,8 +48,6 @@ union alignas(16) Quaternion
     constexpr Vec3              operator*   (const Vec3& v)                         const noexcept;
     constexpr Quaternion        operator*   (const f32 k)                           const noexcept;
     constexpr Quaternion        operator/   (const f32 k)                           const noexcept;
-
-    friend std::ostream&        operator<<  (std::ostream& os, const Quaternion& q) noexcept;
 };
 
 using Quat = Quaternion;

--- a/include/GPM/Quaternion.inl
+++ b/include/GPM/Quaternion.inl
@@ -93,7 +93,3 @@ inline constexpr Quaternion Quaternion::operator/(const f32 k) const noexcept
 
     return {v * reciprocal, s * reciprocal};
 }
-
-
-inline std::ostream& operator<<(std::ostream& os, const Quaternion& q) noexcept
-{ return os << '[' << q.s << ", " << q.v << ']'; }

--- a/include/GPM/ShapeRelation/Intersection.hpp
+++ b/include/GPM/ShapeRelation/Intersection.hpp
@@ -9,6 +9,7 @@
 #include "../Vector3.hpp"
 
 #include <limits>
+#include <utility>
 
 namespace GPM
 {

--- a/include/GPM/Transform.hpp
+++ b/include/GPM/Transform.hpp
@@ -21,8 +21,6 @@ struct SplitTransform
     Quat rotation;
     Vec3 position;
     Vec3 scale;
-
-    friend std::ostream& operator<<(std::ostream& os, const SplitTransform& m) noexcept;
 };
 
 
@@ -95,9 +93,6 @@ struct Transform
                                        const Vec3& r,
                                        const Vec3& s)                         noexcept;
     constexpr void        apply       (const Mat4& m)                         noexcept;
-
-    // Utility
-    friend std::ostream& operator<<(std::ostream& os, const Transform& m)     noexcept;
 };
 
 #include "Transform.inl"

--- a/include/GPM/Transform.hpp
+++ b/include/GPM/Transform.hpp
@@ -34,70 +34,70 @@ struct Transform
     Transform() = default;
     Transform(const Vec3& t,
               const Vec3& r = Vec3::zero(),
-              const Vec3& s = Vec3::one())                               noexcept;
-    constexpr Transform(const Mat4& m)                                   noexcept;
+              const Vec3& s = Vec3::one())                                    noexcept;
+    constexpr Transform(const Mat4& m)                                        noexcept;
 
     // Static methods
-    static constexpr Mat4 translation (const Vec3& t)                     noexcept;
-    static Mat4           rotationX   (const f32 angle)                   noexcept;
-    static Mat4           rotationY   (const f32 angle)                   noexcept;
-    static Mat4           rotationZ   (const f32 angle)                   noexcept;
-    static Mat4           rotation    (const Vec3& t)                     noexcept;
-    static Mat4           rotationAround(const Vec3& axis, const f32 angle) noexcept;
-    static constexpr Mat4 scaling     (const Vec3& t)                     noexcept;
+    static constexpr Mat4 translation (const Vec3& t)                         noexcept;
+    static Mat4           rotationX   (const f32 angle)                       noexcept;
+    static Mat4           rotationY   (const f32 angle)                       noexcept;
+    static Mat4           rotationZ   (const f32 angle)                       noexcept;
+    static Mat4           rotation    (const Vec3& t)                         noexcept;
+    static Mat4           rotationAround(const Vec3& axis, const f32 angle)   noexcept;
+    static constexpr Mat4 scaling     (const Vec3& t)                         noexcept;
     static Mat4           TRS         (const Vec3& t, const Vec3& r,
-                                       const Vec3& s)                     noexcept;
+                                       const Vec3& s)                         noexcept;
     static Mat4           lookAt      (const Vec3& eyePos,
                                        const Vec3& targetPos,
                                        const Vec3& normalizedUp = Vec3::up()) noexcept;
     static constexpr Mat4 symFrustrum (const f32 right, const f32 top,
-                                       const f32 near,  const f32 far)    noexcept;
+                                       const f32 near_, const f32 far_)      noexcept;
     static Mat4           perspective (const f32 fovY,  const f32 aspect,
-                                       const f32 near,  const f32 far)    noexcept;
+                                       const f32 near_, const f32 far_)      noexcept;
     static constexpr Mat4 orthographic(const f32 right, const f32 top,
-                                       const f32 near, const f32 far)     noexcept;
+                                       const f32 near_, const f32 far_)       noexcept;
     static constexpr Mat4 viewport    (const f32 x,     const f32 y,
-                                       const f32 width, const f32 height) noexcept;
+                                       const f32 width, const f32 height)     noexcept;
 
     // Getters
-    Mat4                  normalMat   ()                                  const noexcept;
-    constexpr Vec3        right       ()                                  const noexcept;
-    constexpr Vec3        up          ()                                  const noexcept;
-    constexpr Vec3        forward     ()                                  const noexcept;
-    constexpr Vec3        translation ()                                  const noexcept;
-    Mat4                  rotation    ()                                  const noexcept;
-    Vec3                  eulerAngles ()                                  const noexcept;
-    Vec3                  scaling     ()                                  const noexcept;
+    Mat4                  normalMat   ()                                      const noexcept;
+    constexpr Vec3        right       ()                                      const noexcept;
+    constexpr Vec3        up          ()                                      const noexcept;
+    constexpr Vec3        forward     ()                                      const noexcept;
+    constexpr Vec3        translation ()                                      const noexcept;
+    Mat4                  rotation    ()                                      const noexcept;
+    Vec3                  eulerAngles ()                                      const noexcept;
+    Vec3                  scaling     ()                                      const noexcept;
 
     // Setters
-    constexpr void        setLocalTranslation (const Vec3& t)             noexcept;
-    constexpr void        setGlobalTranslation(const Vec3& t)             noexcept;
-    void                  setRotation         (const Vec3& r)             noexcept;
-    constexpr void        setScale            (const Vec3& s)             noexcept;
+    constexpr void        setLocalTranslation (const Vec3& t)                 noexcept;
+    constexpr void        setGlobalTranslation(const Vec3& t)                 noexcept;
+    void                  setRotation         (const Vec3& r)                 noexcept;
+    constexpr void        setScale            (const Vec3& s)                 noexcept;
 
     // Transformations
-    constexpr void        translateX  (const f32 shift)                   noexcept;
-    constexpr void        translateY  (const f32 shift)                   noexcept;
-    constexpr void        translateZ  (const f32 shift)                   noexcept;
-    constexpr void        translate   (const Vec3& t)                     noexcept;
-    void                  rotateX     (const f32 angle)                   noexcept;
-    void                  rotateY     (const f32 angle)                   noexcept;
-    void                  rotateZ     (const f32 angle)                   noexcept;
-    void                  rotate      (const Vec3& r)                     noexcept;
-    void                  rotateAround(const Vec3& axis, const f32 angle) noexcept;
-    constexpr void        scaleX      (const f32 coef)                    noexcept;
-    constexpr void        scaleY      (const f32 coef)                    noexcept;
-    constexpr void        scaleZ      (const f32 coef)                    noexcept;
-    constexpr void        scale       (const Vec3& s)                     noexcept;
-    void                  lookAt      (const Vec3& targetPos)             noexcept;
+    constexpr void        translateX  (const f32 shift)                       noexcept;
+    constexpr void        translateY  (const f32 shift)                       noexcept;
+    constexpr void        translateZ  (const f32 shift)                       noexcept;
+    constexpr void        translate   (const Vec3& t)                         noexcept;
+    void                  rotateX     (const f32 angle)                       noexcept;
+    void                  rotateY     (const f32 angle)                       noexcept;
+    void                  rotateZ     (const f32 angle)                       noexcept;
+    void                  rotate      (const Vec3& r)                         noexcept;
+    void                  rotateAround(const Vec3& axis, const f32 angle)     noexcept;
+    constexpr void        scaleX      (const f32 coef)                        noexcept;
+    constexpr void        scaleY      (const f32 coef)                        noexcept;
+    constexpr void        scaleZ      (const f32 coef)                        noexcept;
+    constexpr void        scale       (const Vec3& s)                         noexcept;
+    void                  lookAt      (const Vec3& targetPos)                 noexcept;
 
     void                  apply       (const Vec3& t,
                                        const Vec3& r,
-                                       const Vec3& s)                     noexcept;
-    constexpr void        apply       (const Mat4& m)                     noexcept;
+                                       const Vec3& s)                         noexcept;
+    constexpr void        apply       (const Mat4& m)                         noexcept;
 
     // Utility
-    friend std::ostream& operator<<(std::ostream& os, const Transform& m) noexcept;
+    friend std::ostream& operator<<(std::ostream& os, const Transform& m)     noexcept;
 };
 
 #include "Transform.inl"

--- a/include/GPM/Transform.inl
+++ b/include/GPM/Transform.inl
@@ -1,14 +1,3 @@
-/* ================== SplitTransform static methods ================== */
-inline std::ostream& operator<<(std::ostream& os, const SplitTransform& st) noexcept
-{
-    return os << "rotation: "   << st.rotation
-              << "\nposition: " << st.position
-              << "\nscale: "    << st.scale;
-}
-
-
-
-
 /* ================== Transform static methods ================== */
 inline constexpr Mat4 Transform::translation(const Vec3& t) noexcept
 {
@@ -480,10 +469,3 @@ inline constexpr void Transform::apply(const Mat4& m) noexcept
 {
     model *= m;
 }
-
-
-
-
-// Utility
-inline std::ostream& operator<<(std::ostream& os, const Transform& t) noexcept
-{ return os << t.model; }

--- a/include/GPM/Transform.inl
+++ b/include/GPM/Transform.inl
@@ -128,40 +128,40 @@ inline Mat4 Transform::lookAt(const Vec3& eyePos,
 
 
 inline constexpr Mat4 Transform::symFrustrum(const f32 right, const f32 top,
-                                             const f32 near,  const f32 far) noexcept
+                                             const f32 near_, const f32 far_) noexcept
 {
-    const f32 depthInv{1.f / (far - near)};
+    const f32 depthInv{1.f / (far_ - near_)};
 
     return
     {
-        near / right, .0f,        .0f,                          .0f,
-        .0f,          near / top, .0f,                          .0f,
-        .0f,          .0f,        -(far + near) * depthInv,    -1.f,
-        .0f,          .0f,        -2.f * far * near * depthInv, .0f
+        near_ / right, .0f,        .0f,                          .0f,
+        .0f,          near_ / top, .0f,                          .0f,
+        .0f,          .0f,        -(far_ + near_) * depthInv,    -1.f,
+        .0f,          .0f,        -2.f * far_ * near_ * depthInv, .0f
     };
 }
 
 
 inline Mat4 Transform::perspective(const f32 fovY, const f32 aspect,
-                                   const f32 near, const f32 far) noexcept
+                                   const f32 near_, const f32 far_) noexcept
 {
-    const f32 top{near * tanf(fovY / 2.f)}, right{top * aspect};
+    const f32 top{near_ * tanf(fovY / 2.f)};
 
-    return symFrustrum(right, top, near, far);
+    return symFrustrum(top * aspect, top, near_, far_);
 }
 
 
 inline constexpr Mat4 Transform::orthographic(const f32 right, const f32 top,
-                                              const f32 near,  const f32 far) noexcept
+                                              const f32 near_, const f32 far_) noexcept
 {
-    const f32 farMinNear{far - near};
+    const f32 farMinNear{far_ - near_};
 
     return
     {
         1.f / right, .0f,       .0f,                          .0f,
         .0f,         1.f / top, .0f,                          .0f,
         .0f,         .0f,       -2.f / farMinNear,            .0f,
-        .0f,         .0f,       (far + near) / (-farMinNear), 1.f
+        .0f,         .0f,       (far_ + near_) / (-farMinNear), 1.f
     };
 }
 

--- a/include/GPM/Transform.inl
+++ b/include/GPM/Transform.inl
@@ -160,7 +160,7 @@ inline constexpr Mat4 Transform::orthographic(const f32 right, const f32 top,
     {
         1.f / right, .0f,       .0f,                          .0f,
         .0f,         1.f / top, .0f,                          .0f,
-        .0f,         .0f,       -2.f / (far - near),          .0f,
+        .0f,         .0f,       -2.f / farMinNear,            .0f,
         .0f,         .0f,       (far + near) / (-farMinNear), 1.f
     };
 }

--- a/include/GPM/Vector2.hpp
+++ b/include/GPM/Vector2.hpp
@@ -8,7 +8,6 @@
 
 #include <cfloat>
 #include <cmath>
-#include <iostream>
 
 #include "types.hpp"
 
@@ -81,8 +80,6 @@ union Vector2
     constexpr Vector2   operator-           ()                  const noexcept;
     constexpr Vector2   operator*           (const f32 k)       const noexcept;
     constexpr Vector2   operator/           (const f32 k)       const noexcept;
-
-    friend std::ostream& operator<<         (std::ostream& os, const Vector2& v) noexcept;
 };
 
 using Vec2 = Vector2;

--- a/include/GPM/Vector2.inl
+++ b/include/GPM/Vector2.inl
@@ -289,7 +289,3 @@ inline constexpr Vector2 Vector2::operator/(const f32 k) const noexcept
 
 	return {x * reciprocal, y * reciprocal};
 }
-
-
-inline std::ostream& operator<<(std::ostream& os, const Vector2& v) noexcept
-{ return os << '[' << v.x << ", " << v.y << ']'; }

--- a/include/GPM/Vector3.hpp
+++ b/include/GPM/Vector3.hpp
@@ -8,7 +8,6 @@
 
 #include <cfloat>
 #include <cmath>
-#include <iostream>
 
 #include "Vector2.hpp"
 
@@ -100,8 +99,6 @@ union Vector3
     constexpr Vector3   operator-           ()                              const noexcept;
     constexpr Vector3	operator*           (const f32 k)                   const noexcept;
     constexpr Vector3	operator/           (const f32 k)                   const noexcept;
-
-    friend std::ostream& operator<<         (std::ostream& os, const Vector3& v) noexcept;
 };
 
 constexpr Vector3	operator*           (const f32 k, const Vector3& v)     noexcept;

--- a/include/GPM/Vector3.inl
+++ b/include/GPM/Vector3.inl
@@ -322,10 +322,6 @@ inline constexpr Vector3 Vector3::operator/(const f32 k) const noexcept
 }
 
 
-inline std::ostream& operator<<(std::ostream& os, const Vector3& v) noexcept
-{ return os << '[' << v.x << ", " << v.y << ", " << v.z << ']'; }
-
-
 inline constexpr Vector3 operator*(const f32 k, const Vector3& v) noexcept
 {
     return v * k;

--- a/include/GPM/Vector4.hpp
+++ b/include/GPM/Vector4.hpp
@@ -8,7 +8,6 @@
 
 #include <cfloat>
 #include <cmath>
-#include <iostream>
 
 #include "Vector3.hpp"
 
@@ -57,8 +56,6 @@ union alignas(16) Vector4
     constexpr Vector4  operator/  (const Vector4& v) const noexcept;
     constexpr Vector4  operator*  (const f32 k)      const noexcept;
     constexpr Vector4  operator/  (const f32 k)      const noexcept;
-
-    friend std::ostream& operator<<(std::ostream& os, const Vector4& v) noexcept;
 };
 
 using Vec4 = Vector4;

--- a/include/GPM/Vector4.inl
+++ b/include/GPM/Vector4.inl
@@ -67,7 +67,3 @@ inline constexpr Vector4 Vector4::operator/(const f32 k) const noexcept
     const f32 reciprocal{1.f / k};
     return {xyz * reciprocal, w * reciprocal};
 }
-
-
-inline std::ostream& operator<<(std::ostream& os, const Vector4& v) noexcept
-{ return os << '[' << v.xyz.x << ", " << v.xyz.y << ", " << v.xyz.z << ", " << v.w << ']'; }

--- a/include/GPM/conversion.inl
+++ b/include/GPM/conversion.inl
@@ -69,9 +69,8 @@ inline Quat toQuaternion(const Mat3& m) noexcept
         if (m.e[4] > m.e[0])      i = 1u;
         if (m.e[8] > m.c[i].e[i]) i = 2u;
 
-        const u8 NEXT[3]    = {1u, 2u, 0u},
-                 j          = NEXT[i],
-                 k          = NEXT[j];
+        constexpr u8 NEXT[3]{1u, 2u, 0u};
+        const     u8 j = NEXT[i], k = NEXT[j];
 
         f32 tmp = sqrtf(m.c[i].e[i] - (m.c[j].e[j] + m.c[k].e[k]) + 1.f);
 


### PR DESCRIPTION
Contains a set of small fixes for optimization and errors of inattention. Also addresses the shadowing of the `far` and `near` macros defined in `minwindef.h`. `far` and `near` were 2 variable names used to generate view-related matrices.

Also moved all `std::ostream& operator<<` methods to a single file, to prevent compilation times.

All new methods have been tested and validated before this pull request was sent.