### PR TITLE
Transform::forward() --> Transform::backward()

### DIFF
--- a/include/GPM/Quaternion.inl
+++ b/include/GPM/Quaternion.inl
@@ -31,8 +31,8 @@ inline Quaternion Quaternion::fromEuler(const Vec3& angles) noexcept
     const Vec3 imAxis
     {
         sinX * cosYcosZ - cosX * sinYsinZ,
-        cosX * sinYcosZ + sinX * cosYsinZ,
-        cosX * cosYsinZ - sinX * sinYcosZ
+        cosX * cosYsinZ - sinX * sinYcosZ,
+        cosX * sinYcosZ + sinX * cosYsinZ
     };
 
     return {imAxis, cosX * cosYcosZ + sinX * sinYsinZ};

--- a/include/GPM/Transform.hpp
+++ b/include/GPM/Transform.hpp
@@ -61,7 +61,7 @@ struct Transform
     Mat4                  normalMat   ()                                      const noexcept;
     constexpr Vec3        right       ()                                      const noexcept;
     constexpr Vec3        up          ()                                      const noexcept;
-    constexpr Vec3        forward     ()                                      const noexcept;
+    constexpr Vec3        backward    ()                                      const noexcept;
     constexpr Vec3        translation ()                                      const noexcept;
     Mat4                  rotation    ()                                      const noexcept;
     Vec3                  eulerAngles ()                                      const noexcept;

--- a/include/GPM/Transform.inl
+++ b/include/GPM/Transform.inl
@@ -108,11 +108,11 @@ inline Mat4 Transform::lookAt(const Vec3& eyePos,
                               const Vec3& targetPos,
                               const Vec3& normalizedUp) noexcept
 {
-    const Vec4 forward{(eyePos - targetPos).normalized(), .0f},
-               right  {normalizedUp.cross(forward.xyz),   .0f},
-               up     {forward.xyz.cross(right.xyz),      .0f};
+    const Vec4 backward{(eyePos - targetPos).normalized(), .0f},
+               right   {normalizedUp.cross(backward.xyz),   .0f},
+               up      {backward.xyz.cross(right.xyz),      .0f};
 
-    return {right, up, forward, eyePos};
+    return {right, up, backward, eyePos};
 }
 
 
@@ -207,7 +207,7 @@ inline constexpr Vec3 Transform::up() const noexcept
 }
 
 
-inline constexpr Vec3 Transform::forward() const noexcept
+inline constexpr Vec3 Transform::backward() const noexcept
 {
     return model.c[2].xyz;
 }
@@ -222,7 +222,7 @@ inline constexpr Vec3 Transform::translation() const noexcept
 
 inline Mat4 Transform::rotation() const noexcept
 {
-    const Vec3 invScale{1.f / right().length(), 1.f / up().length(), 1.f / forward().length()};
+    const Vec3 invScale{1.f / right().length(), 1.f / up().length(), 1.f / backward().length()};
 
     return
     {
@@ -257,7 +257,7 @@ inline Vec3 Transform::eulerAngles() const noexcept
 
 inline Vec3 Transform::scaling() const noexcept
 {
-    return {right().length(), up().length(), forward().length()};
+    return {right().length(), up().length(), backward().length()};
 }
 
 


### PR DESCRIPTION
I made the mistake of believing that the third column in a 4x4 matrix was the forward vector of the referential it represents.
It is actually the backward vector of the referential it represents.

`Transform::forward()` has been removed and renamed `Transform::backward()` to make sure errors are raised were `Transform::forward()` was used.

EDIT: Also added a fix for `Quaternion::fromEuler(const Vec3& angles)`, which inverted the Y and Z axis.